### PR TITLE
Syntax fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Actions"
           git add --all
-          if [-z "$(git status --porcelain)"]; then
+          if [ -z "$(git status --porcelain)" ]; then
               echo "::set-output name=push::true"
           else
               git commit -m "Add changes" -a


### PR DESCRIPTION
Added spaces around git porcelain check to prevent pipeline failure on unchanged repo.